### PR TITLE
UI: remove redundant commas in tags list (services view)

### DIFF
--- a/ui/javascripts/app/routes.js
+++ b/ui/javascripts/app/routes.js
@@ -250,7 +250,9 @@ App.ServicesShowRoute = App.BaseRoute.extend({
   setupController: function(controller, model) {
     var tags = [];
     model.map(function(obj){
-      tags = tags.concat(obj.Service.Tags);
+      if (obj.Service.Tags !== null) {
+        tags = tags.concat(obj.Service.Tags);
+      }
     });
 
     tags = tags.filter(function(n){ return n !== undefined; });


### PR DESCRIPTION
When some services had no tags(Tags is null) and some did have tags redundant commas were added to the tags list.